### PR TITLE
filter_planetestream: Move and rename filter class for MDL-82427

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -21,11 +21,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-global $CFG;
-require_once($CFG->libdir . '/filelib.php');
-defined('MOODLE_INTERNAL') || die();
-class filter_planetestream extends moodle_text_filter
-{
+
+namespace filter_planetestream;
+
+class text_filter extends \moodle_text_filter {
+
     /**
      * Get attribute from tag
      *


### PR DESCRIPTION
This is necessary to avoid a bunch of page breaking debug messages in Moodle 4.5